### PR TITLE
fixed another datatype-bug.

### DIFF
--- a/tt/core/tt.py
+++ b/tt/core/tt.py
@@ -539,8 +539,8 @@ class matrix:
                 n1 = np.sqrt(a.n).astype(np.int32)
                 m1 = np.sqrt(a.n).astype(np.int32)
             else:
-                n1 = np.array(n,dtype=np.int32)
-                m1 = np.array(m,dtype=np.int32)
+                n1 = np.array([n],dtype=np.int32)
+                m1 = np.array([m],dtype=np.int32)
             self.n = n1
             self.m = m1
             self.tt.core = a.core.copy()


### PR DESCRIPTION
If s is a scalar, np.array(s) returns an array without dimensions, instead of an array of shape (1,1). But all methods in tt.core.tt require n and m to be of that form.