### PR TITLE
Fix example of matrix functionality.

### DIFF
--- a/examples/test_common.py
+++ b/examples/test_common.py
@@ -1,15 +1,33 @@
-import sys
-sys.path.append('../')
-from tt import *
-import numpy as np
+#!/usr/bin/env python2
+#   test_common.py
+#   See LICENSE for details
+"""Test common matrix operation with QTT-toolbox like matmat-operation and matvec-operation.
+"""
 
-x = xfun(2, 3)
-e = ones(2, 2)
-X = matrix(x, [2]*3, [1]*3) # [0, 1, 2, 3, 4, 5, 6, 7]^T
-E = matrix(e, [1]*2, [2]*2) # [1, 1, 1, 1]
-print (X * E).full()
+from __future__ import print_function, absolute_import, division
+import numpy as np
+import sys
+
+sys.path.append('../')
+
+import tt
+
+
+x = tt.xfun(2, 3)
+e = tt.ones(2, 2)
+X = tt.matrix(x, n=[2] * 3, m=[1] * 3) # [0, 1, 2, 3, 4, 5, 6, 7]^T
+E = tt.matrix(e, n=[1] * 2, m=[2] * 2) # [1, 1, 1, 1]
+#[[ 0.  0.  0.  0.]
+# [ 1.  1.  1.  1.]
+# [ 2.  2.  2.  2.]
+# [ 3.  3.  3.  3.]
+# [ 4.  4.  4.  4.]
+# [ 5.  5.  5.  5.]
+# [ 6.  6.  6.  6.]
+# [ 7.  7.  7.  7.]]
+print((X * E).full())
 assert np.all((X * E) * np.arange(4) == np.arange(8) * 6.)
 
-A = matrix(xfun(2, 3), [1] * 3, [2] * 3)
+A = tt.matrix(tt.xfun(2, 3), n=[1] * 3, m=[2] * 3)
 u = np.arange(8)
 assert A * u == 140.

--- a/tt/core/tt.py
+++ b/tt/core/tt.py
@@ -562,8 +562,8 @@ class matrix:
                 n1 = _np.sqrt(a.n).astype(_np.int32)
                 m1 = _np.sqrt(a.n).astype(_np.int32)
             else:
-                n1 = _np.array([n], dtype = _np.int32)
-                m1 = _np.array([m], dtype = _np.int32)
+                n1 = _np.array(n, dtype = _np.int32)
+                m1 = _np.array(m, dtype = _np.int32)
             self.n = n1
             self.m = m1
             self.tt.core = a.core.copy()


### PR DESCRIPTION
Example `test_common.py` fails with raise an exception. The reason is inconsistence of the example with core functionality.