### PR TITLE
Fix hardcoded fortran compiler argument.

### DIFF
--- a/tt/setup.py
+++ b/tt/setup.py
@@ -4,7 +4,6 @@ from numpy.distutils.misc_util import Configuration, get_info
 import sys
 
 def configuration(parent_package='',top_path=None):
-    sys.argv.extend ( ['config_fc', '--fcompiler=gnu95'])
     config = Configuration('tt', parent_package, top_path)
     config.set_options(ignore_setup_xxx_py=True,
                        assume_default_configuration=True,


### PR DESCRIPTION
There is hardcoded Fortran compiler flag which do not allow compile with another compiler(e.g. Intel Fortran not GNU Fortran). By default `numpy.distutils` sets compiler but still user could pass prefered compiler in following way `python setup.py build --fcompiler=intelem`.