### PR TITLE
tools.py/reshape: fixed float shape (tt.n) in output (to int)

### DIFF
--- a/tt/core/tools.py
+++ b/tt/core/tools.py
@@ -1074,6 +1074,7 @@ def reshape(tt_array, shape, eps=1e-14, rl=1, rr=1):
     tt2.n[d2 - 1] = tt2.n[d2 - 1] / rr
     tt2.r[0] = rl
     tt2.r[d2] = rr
+    tt2.n = tt2.n.astype('i')
 
     if ismatrix:
         ttt = eye(1, 1)  # dummy tt _matrix


### PR DESCRIPTION
tt/tools.py, reshape:
Output tt.vector had mode sizes as floats (tt.n), fixed to integer.
