### PR TITLE
tt_min fix for NumPy >= 1.12

### DIFF
--- a/tt/optimize/tt_min.py
+++ b/tt/optimize/tt_min.py
@@ -70,7 +70,7 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
     swp = 0
     dirn = -1
     i = d - 1
-    lm = 999999999999
+    lm = float('Inf')
     while swp < nswp:
         # Right-to-left sweep
         # The idea: compute the current core; compute the function of it;
@@ -178,7 +178,7 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
     swp = 0
     dirn = -1
     i = d - 1
-    lm = 999999999999
+    lm = float('Inf')
     while swp < nswp:
         # Right-to-left sweep
         # The idea: compute the current core; compute the function of it;

--- a/tt/optimize/tt_min.py
+++ b/tt/optimize/tt_min.py
@@ -39,11 +39,11 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
         smooth_fun = lambda p, lam: (math.pi / 2 - np.arctan(p - lam))
     #smooth_fun = lambda p, lam: np.exp(-10*(p - lam))
 
-        # We do not need to store the cores, only the interfaces!
+    # We do not need to store the cores, only the interfaces!
     Rx = [[]] * (d + 1)  # Python list for the interfaces
     Rx[0] = np.ones((1, 1))
     Rx[d] = np.ones((1, 1))
-    Jy = [np.empty(0)] * (d + 1)
+    Jy = [np.empty(0, dtype=np.int)] * (d + 1)
     ry = rmax * np.ones(d + 1, dtype=np.int)
     ry[0] = 1
     ry[d] = 1
@@ -59,8 +59,8 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
         cr1 = reshape(cr1, (ry[i] * n[i], ry[i + 1]))
         q, r = np.linalg.qr(cr1)
         ind = maxvol(q)
-        w1 = mkron(np.ones((n[i], 1)), Jy[i])
-        w2 = mkron(grid[i], np.ones((ry[i], 1)))
+        w1 = mkron(np.ones((n[i], 1), dtype=np.int), Jy[i])
+        w2 = mkron(grid[i], np.ones((ry[i], 1), dtype=np.int))
         Jy[i + 1] = np.hstack((w1, w2))
         Jy[i + 1] = reshape(Jy[i + 1], (ry[i] * n[i], -1))
         Jy[i + 1] = Jy[i + 1][ind, :]
@@ -78,15 +78,15 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
         # Compute the current core
 
         if np.size(Jy[i]) == 0:
-            w1 = np.zeros((ry[i] * n[i] * ry[i + 1], 0))
+            w1 = np.zeros((ry[i] * n[i] * ry[i + 1], 0), dtype=np.int)
         else:
-            w1 = mkron(np.ones((n[i] * ry[i + 1], 1)), Jy[i])
-        w2 = mkron(mkron(np.ones((ry[i + 1], 1)),
-                         grid[i]), np.ones((ry[i], 1)))
+            w1 = mkron(np.ones((n[i] * ry[i + 1], 1), dtype=np.int), Jy[i])
+        w2 = mkron(mkron(np.ones((ry[i + 1], 1), dtype=np.int),
+                         grid[i]), np.ones((ry[i], 1), dtype=np.int))
         if np.size(Jy[i + 1]) == 0:
-            w3 = np.zeros((ry[i] * n[i] * ry[i + 1], 0))
+            w3 = np.zeros((ry[i] * n[i] * ry[i + 1], 0), dtype=np.int)
         else:
-            w3 = mkron(Jy[i + 1], np.ones((ry[i] * n[i], 1)))
+            w3 = mkron(Jy[i + 1], np.ones((ry[i] * n[i], 1), dtype=np.int))
 
         J = np.hstack((w1, w2, w3))
         # Just add some random indices to J, which is rnr x d, need to make rn (r + r0) x add,
@@ -113,11 +113,11 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
             q = u[:, :ry[i]]
             ind = rect_maxvol(q)[0]  # maxvol(q)
             ry[i] = ind.size
-            w1 = mkron(np.ones((ry[i + 1], 1)), grid[i])
+            w1 = mkron(np.ones((ry[i + 1], 1), dtype=np.int), grid[i])
             if np.size(Jy[i + 1]) == 0:
-                w2 = np.zeros((n[i] * ry[i + 1], 0))
+                w2 = np.zeros((n[i] * ry[i + 1], 0), dtype=np.int)
             else:
-                w2 = mkron(Jy[i + 1], np.ones((n[i], 1)))
+                w2 = mkron(Jy[i + 1], np.ones((n[i], 1), dtype=np.int))
             Jy[i] = np.hstack((w1, w2))
             Jy[i] = reshape(Jy[i], (n[i] * ry[i + 1], -1))
             Jy[i] = Jy[i][ind, :]
@@ -128,8 +128,8 @@ def min_func(fun, bounds_min, bounds_max, d=None, rmax=10,
             #ind = maxvol(q)
             ind = rect_maxvol(q)[0]
             ry[i + 1] = ind.size
-            w1 = mkron(np.ones((n[i], 1)), Jy[i])
-            w2 = mkron(grid[i], np.ones((ry[i], 1)))
+            w1 = mkron(np.ones((n[i], 1), dtype=np.int), Jy[i])
+            w2 = mkron(grid[i], np.ones((ry[i], 1), dtype=np.int))
             Jy[i + 1] = np.hstack((w1, w2))
             Jy[i + 1] = reshape(Jy[i + 1], (ry[i] * n[i], -1))
             Jy[i + 1] = Jy[i + 1][ind, :]
@@ -150,7 +150,7 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
     Rx = [[]] * (d + 1)  # Python list for the interfaces
     Rx[0] = np.ones((1, 1))
     Rx[d] = np.ones((1, 1))
-    Jy = [np.empty(0)] * (d + 1)
+    Jy = [np.empty(0, dtype=np.int)] * (d + 1)
     ry = rmax * np.ones(d + 1, dtype=np.int)
     ry[0] = 1
     ry[d] = 1
@@ -167,8 +167,8 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
     for i in xrange(d - 1):
         ry[i + 1] = min(ry[i + 1], n[i] * ry[i])
         ind = sorted(np.random.permutation(ry[i] * n[i])[0:ry[i + 1]])
-        w1 = mkron(np.ones((n[i], 1)), Jy[i])
-        w2 = mkron(grid[i], np.ones((ry[i], 1)))
+        w1 = mkron(np.ones((n[i], 1), dtype=np.int), Jy[i])
+        w2 = mkron(grid[i], np.ones((ry[i], 1), dtype=np.int))
         Jy[i + 1] = np.hstack((w1, w2))
         Jy[i + 1] = reshape(Jy[i + 1], (ry[i] * n[i], -1))
         Jy[i + 1] = Jy[i + 1][ind, :]
@@ -186,15 +186,15 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
         # Compute the current core
 
         if np.size(Jy[i]) == 0:
-            w1 = np.zeros((ry[i] * n[i] * ry[i + 1], 0))
+            w1 = np.zeros((ry[i] * n[i] * ry[i + 1], 0), dtype=np.int)
         else:
-            w1 = mkron(np.ones((n[i] * ry[i + 1], 1)), Jy[i])
-        w2 = mkron(mkron(np.ones((ry[i + 1], 1)),
-                         grid[i]), np.ones((ry[i], 1)))
+            w1 = mkron(np.ones((n[i] * ry[i + 1], 1), dtype=np.int), Jy[i])
+        w2 = mkron(mkron(np.ones((ry[i + 1], 1), dtype=np.int),
+                         grid[i]), np.ones((ry[i], 1), dtype=np.int))
         if np.size(Jy[i + 1]) == 0:
-            w3 = np.zeros((ry[i] * n[i] * ry[i + 1], 0))
+            w3 = np.zeros((ry[i] * n[i] * ry[i + 1], 0), dtype=np.int)
         else:
-            w3 = mkron(Jy[i + 1], np.ones((ry[i] * n[i], 1)))
+            w3 = mkron(Jy[i + 1], np.ones((ry[i] * n[i], 1), dtype=np.int))
         J = np.hstack((w1, w2, w3))
 
         phi_right[i] = np.tensordot(cores[i], phi_right[i + 1], 1)
@@ -224,11 +224,11 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
             q = u[:, :ry[i]]
             ind = rect_maxvol(q)[0]  # maxvol(q)
             ry[i] = ind.size
-            w1 = mkron(np.ones((ry[i + 1], 1)), grid[i])
+            w1 = mkron(np.ones((ry[i + 1], 1), dtype=np.int), grid[i])
             if np.size(Jy[i + 1]) == 0:
-                w2 = np.zeros((n[i] * ry[i + 1], 0))
+                w2 = np.zeros((n[i] * ry[i + 1], 0), dtype=np.int)
             else:
-                w2 = mkron(Jy[i + 1], np.ones((n[i], 1)))
+                w2 = mkron(Jy[i + 1], np.ones((n[i], 1), dtype=np.int))
             Jy[i] = np.hstack((w1, w2))
             Jy[i] = reshape(Jy[i], (n[i] * ry[i + 1], -1))
             Jy[i] = Jy[i][ind, :]
@@ -245,8 +245,8 @@ def min_tens(tens, rmax=10, nswp=10, verb=True, smooth_fun=None):
             phi_left[i + 1] = np.tensordot(phi_left[i], cores[i], 1)
             phi_left[i + 1] = reshape(phi_left[i + 1], (ry[i] * n[i], -1))
             phi_left[i + 1] = phi_left[i + 1][ind, :]
-            w1 = mkron(np.ones((n[i], 1)), Jy[i])
-            w2 = mkron(grid[i], np.ones((ry[i], 1)))
+            w1 = mkron(np.ones((n[i], 1), dtype=np.int), Jy[i])
+            w2 = mkron(grid[i], np.ones((ry[i], 1), dtype=np.int))
             Jy[i + 1] = np.hstack((w1, w2))
             Jy[i + 1] = reshape(Jy[i + 1], (ry[i] * n[i], -1))
             Jy[i + 1] = Jy[i + 1][ind, :]


### PR DESCRIPTION
Beginning in NumPy 1.12, accessing an array with a float index causes an index error. These fixes ensure that the tensor is accessed by integers in the tt_min module