### PR TITLE
master: fix TypeError with tt.unit

### DIFF
--- a/tt/core/tools.py
+++ b/tt/core/tools.py
@@ -777,7 +777,7 @@ def unit(n, d=None, j=None, tt_instance=True):
     if isinstance(n, int):
         if d is None:
             d = 1
-        n = n * _np.ones(d)
+        n = n * _np.ones(d, dtype=_np.int32)
     else:
         d = len(n)
     if j is None:

--- a/tt/core/utils.py
+++ b/tt/core/utils.py
@@ -22,7 +22,7 @@ def ind2sub(siz, idx):
     for i in xrange(n - 1, -1, -1):
         subs[i] = _np.floor(idx / k[i])
         idx = idx % k[i]
-    return subs
+    return subs.astype(_np.int32)
     
 def gcd(a, b):
     '''Greatest common divider'''


### PR DESCRIPTION
Fix the following problem:
```
>> tt.unit(2, 4, 0)
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/home/lmarkeeva/anaconda2/lib/python2.7/site-packages/tt/core/tools.py", line 790, in unit
rv.append(_np.zeros((1, n[k], 1)))
TypeError: 'numpy.float64' object cannot be interpreted as an index
```

This pull request force casts the result of tt.core.utils.ind2sub and modes generation at tt.unit to np.int32 in the case of integer input n.