### PR TITLE
Allow argument mismatch for GCC Fortran 11  (#82)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,15 @@ TT-format in Python. It is able to do TT-interpolation, solve linear systems, ei
 Several computational routines are done in Fortran (which can be used separatedly), and are wrapped with the f2py tool.
 """
 
+import builtins
+
 from numpy.distutils.core import setup
 from numpy.distutils.misc_util import Configuration
+
+# This is a hack to build ttpy from source tree. We set the variable in order
+# to avoid loading of modules which are not built yet. The same work around is
+# used in NumPy.
+builtins.__TTPY_SETUP__ = True
 
 DOCLINES = (__doc__ or '').split('\n')
 
@@ -77,3 +84,5 @@ def setup_package():
 
 if __name__ == '__main__':
     setup_package()
+    # Remove flag to avoid potential problems.
+    del builtins.__TTPY_SETUP__

--- a/tt/__init__.py
+++ b/tt/__init__.py
@@ -1,22 +1,32 @@
 from __future__ import print_function, absolute_import, division
-from sys import platform
+from sys import platform, stderr
 
+# First of all, we should check context in which package is loaded. If there is
+# such variable then we should to avoid loading of submodules.
 try:
-    from .core.tt import *
-except:
-    import ctypes
-    try:
-        ctypes.CDLL("libmkl_rt.so", ctypes.RTLD_GLOBAL)
-    except:
-        try:
-            if platform.startswith('linux'):
-                ctypes.CDLL("liblapack.so", ctypes.RTLD_GLOBAL)
-            elif platform.startswith('darwin'):
-                ctypes.CDLL("liblapack.dylib", ctypes.RTLD_GLOBAL)
-        except:
-            print("Did not find MKL or LAPACK library")
-    from .core.tt import *
+    __TTPY_SETUP__
+except NameError:
+    __TTPY_SETUP__ = False
 
-from .multifuncrs import multifuncrs
-from .multifuncrs2 import multifuncrs2
-from .solvers import GMRES
+if __TTPY_SETUP__:
+    stderr.write('Building from ttpy source directory.\n')
+else:
+    try:
+        from .core.tt import *
+    except:
+        import ctypes
+        try:
+            ctypes.CDLL("libmkl_rt.so", ctypes.RTLD_GLOBAL)
+        except:
+            try:
+                if platform.startswith('linux'):
+                    ctypes.CDLL("liblapack.so", ctypes.RTLD_GLOBAL)
+                elif platform.startswith('darwin'):
+                    ctypes.CDLL("liblapack.dylib", ctypes.RTLD_GLOBAL)
+            except:
+                print("Did not find MKL or LAPACK library")
+        from .core.tt import *
+
+    from .multifuncrs import multifuncrs
+    from .multifuncrs2 import multifuncrs2
+    from .solvers import GMRES

--- a/tt/core/setup.py
+++ b/tt/core/setup.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 from numpy.distutils.misc_util import Configuration
 from os.path import join
+from tt.distutils import get_extra_fflags
 
 
 TTFORT_DIR = '../tt-fort'
@@ -40,6 +41,7 @@ def configuration(parent_package='', top_path=None):
     config.add_extension(
         'core_f90',
         sources=ttcore_src,
+        extra_f90_compile_args=get_extra_fflags(),
     )
 
     return config

--- a/tt/distutils.py
+++ b/tt/distutils.py
@@ -1,0 +1,10 @@
+from numpy.distutils import customized_fcompiler
+
+
+def get_extra_fflags():
+    fflags = []
+    fcompiler = customized_fcompiler()
+    if fcompiler.compiler_type in ('g95', 'gnu', 'gnu95'):
+        if fcompiler.get_version() >= '11.0':
+            fflags.append('-fallow-argument-mismatch')
+    return fflags

--- a/tt/eigb/setup.py
+++ b/tt/eigb/setup.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 from numpy.distutils.misc_util import Configuration
 from os.path import join
+from tt.distutils import get_extra_fflags
 
 
 TTFORT_DIR = '../tt-fort/'
@@ -39,6 +40,7 @@ def configuration(parent_package='', top_path=None):
             'mytt',
             'print_lib',
         ],
+        extra_f90_compile_args=get_extra_fflags(),
     )
 
     return config

--- a/tt/ksl/setup.py
+++ b/tt/ksl/setup.py
@@ -5,6 +5,7 @@
 from __future__ import print_function, absolute_import
 from numpy.distutils.misc_util import Configuration
 from os.path import join
+from tt.distutils import get_extra_fflags
 
 
 TTFORT_DIR = '../tt-fort'
@@ -33,10 +34,14 @@ def configuration(parent_package='', top_path=None):
     ttksl_src = [join(TTFORT_DIR, x) for x in TTKSL_SRC]
     ttksl_src.append('tt_ksl.pyf')
 
+    fflags = get_extra_fflags()
+
     config = Configuration('ksl', parent_package, top_path)
     config.add_library(
         'expokit',
         sources=expokit_src,
+        extra_f77_compile_args=fflags,
+        extra_f90_compile_args=fflags,
     )
     config.add_extension(
         'dyn_tt',
@@ -51,6 +56,7 @@ def configuration(parent_package='', top_path=None):
             'expokit',
             'mytt',
         ],
+        extra_f90_compile_args=fflags,
     )
 
     return config

--- a/tt/setup.py
+++ b/tt/setup.py
@@ -10,6 +10,8 @@ from os.path import join
 
 import sys
 
+from tt.distutils import get_extra_fflags
+
 
 TTFORT_DIR = 'tt-fort'
 TTFORT_SRC = [
@@ -61,7 +63,9 @@ def configuration(parent_package='', top_path=None):
     )
 
     config.add_library('print_lib', sources=[join(PRINT_DIR, x) for x in PRINT_SRC])
-    config.add_library('mytt', sources=[join(TTFORT_DIR, x) for x in TTFORT_SRC])
+    config.add_library(name='mytt',
+                       sources=[join(TTFORT_DIR, x) for x in TTFORT_SRC],
+                       extra_f90_compile_args=get_extra_fflags())
 
     config.add_subpackage('core')
     config.add_subpackage('amen')


### PR DESCRIPTION
Solution for oseledets/ttpy#82 and work around for oseledets/tt-fort#12.