### PR TITLE
Use proper GCD due deprecation at bpo-39350

### DIFF
--- a/tt/core/utils.py
+++ b/tt/core/utils.py
@@ -1,10 +1,16 @@
 from __future__ import print_function, absolute_import, division
 from six.moves import xrange
+import sys
 import numpy as _np
-import fractions as _fractions
+
+if sys.version_info < (3, 5):
+    from fractions import gcd as _gcd
+else:
+    from math import gcd as _gcd
 
 # Available functions:
 # ind2sub, gcd, my_chop2
+
 
 def ind2sub(siz, idx):
     '''
@@ -23,11 +29,13 @@ def ind2sub(siz, idx):
         subs[i] = _np.floor(idx / k[i])
         idx = idx % k[i]
     return subs.astype(_np.int32)
-    
+
+
 def gcd(a, b):
     '''Greatest common divider'''
-    f = _np.frompyfunc(_fractions.gcd, 2, 1)
+    f = _np.frompyfunc(_gcd, 2, 1)
     return f(a, b)
+
 
 def my_chop2(sv, eps):  # from ttpy/multifuncr.py
     if eps <= 0.0:


### PR DESCRIPTION
Function `fractions.gcd` was deprecated since Python 3.5 (bpo-22486) and removed since Python 3.9 (bpo-39350). Now, we should use `math.gcd` instead of `fractions.gcd`.