### PR TITLE
change version to '11' from '11.0'

### DIFF
--- a/tt/distutils.py
+++ b/tt/distutils.py
@@ -5,6 +5,6 @@ def get_extra_fflags():
     fflags = []
     fcompiler = customized_fcompiler()
     if fcompiler.compiler_type in ('g95', 'gnu', 'gnu95'):
-        if fcompiler.get_version() >= '11.0':
+        if fcompiler.get_version() >= '11':
             fflags.append('-fallow-argument-mismatch')
     return fflags


### PR DESCRIPTION
Here is an illustration of the issue:
```
>>> from numpy.distutils import customized_fcompiler
>>> v=fcompiler.get_version(); v
LooseVersion ('10')
>>> v>="10.0"
False
>>> v>="10"
True
```